### PR TITLE
feat: restore non promise interface of connection

### DIFF
--- a/Collection.spec.ts
+++ b/Collection.spec.ts
@@ -13,11 +13,10 @@ type Type = {
 }
 
 describe("Collection", () => {
-	let connection: persistly.TestConnection
+	const connection = persistly.TestConnection.create()
 	let collection: persistly.Collection<Type, "shard"> | undefined
 
 	beforeAll(async () => {
-		connection = await persistly.TestConnection.create()
 		collection = await connection.get<Type, "shard">("data", "shard", 4)
 		if (collection) {
 			await collection.create([

--- a/Connection.ts
+++ b/Connection.ts
@@ -5,8 +5,8 @@ import { Document } from "./Document"
 export class Connection {
 	private client: Promise<Mongo.MongoClient | undefined>
 	private readonly database: Promise<Mongo.Db | undefined>
-	protected constructor(url: string, database?: Promise<string>) {
-		this.client = Mongo.MongoClient.connect(url).catch(() => undefined)
+	protected constructor(url: Promise<string>, database?: Promise<string>) {
+		this.client = url.then(u => Mongo.MongoClient.connect(u).catch(() => undefined))
 		this.database = this.client
 			.then(async c => (c ? c.db(database ? await database : undefined) : undefined))
 			.catch(() => undefined)
@@ -25,6 +25,6 @@ export class Connection {
 			await client.close()
 	}
 	static open(url: string, database?: string): Connection {
-		return new Connection(url, database ? Promise.resolve(database) : undefined)
+		return new Connection(Promise.resolve(url), database ? Promise.resolve(database) : undefined)
 	}
 }

--- a/TestConnection.spec.ts
+++ b/TestConnection.spec.ts
@@ -2,13 +2,13 @@ import { TestConnection } from "./TestConnection"
 
 describe("TestConnection", () => {
 	it("create & close", async () => {
-		const connection = await TestConnection.create()
+		const connection = TestConnection.create()
 		expect(connection).toBeTruthy()
 		await connection.close()
 	})
 	it("get", async () => {
-		const connection = await TestConnection.create()
-		const collection = connection.get<{ id: string; name: string }, "id">("data", "id")
+		const connection = TestConnection.create()
+		const collection = await connection.get<{ id: string; name: string }, "id">("data", "id")
 		expect(collection).toBeTruthy()
 		await connection.close()
 	})

--- a/TestConnection.ts
+++ b/TestConnection.ts
@@ -2,15 +2,14 @@ import { MongoMemoryServer } from "mongodb-memory-server"
 import { Connection } from "./Connection"
 
 export class TestConnection extends Connection {
-	constructor(private server: MongoMemoryServer) {
-		super(server.getUri())
+	constructor(private server: Promise<MongoMemoryServer>) {
+		super(server.then(s => s.getUri()))
 	}
 	async close(): Promise<void> {
 		await super.close()
-		await this.server.stop()
+		await (await this.server).stop()
 	}
-	static async create(): Promise<TestConnection> {
-		const server = await MongoMemoryServer.create()
-		return new TestConnection(server)
+	static create(): TestConnection {
+		return new TestConnection(MongoMemoryServer.create())
 	}
 }


### PR DESCRIPTION
Reverted some promise interface changes that was not necessary and caused unnecessary double awaits in implementing code. This was only because of TestConnection.create() being changed to async in https://github.com/utily/persistly/pull/50, this particular change was now reverted.